### PR TITLE
[TEST] auth관련 테스트 코드 작성 및 websocket configue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	// webclient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// websocket & stomp
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	// websocket & stomp
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+	// mongodb
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/connective/server/chat/global/config/WebSocketConfig.java
+++ b/src/main/java/com/connective/server/chat/global/config/WebSocketConfig.java
@@ -1,0 +1,29 @@
+package com.connective.server.chat.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // 메시지 브로커 활성화 (클라이언트가 구독할 prefix)
+        config.enableSimpleBroker("/topic", "/queue");
+        
+        // 클라이언트에서 메시지를 보낼 때 사용할 prefix
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // WebSocket 연결을 위한 엔드포인트 등록
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*") // CORS 설정 (개발환경용)
+                .withSockJS(); // SockJS fallback 지원
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+    mongodb:
+      uri: mongodb://localhost:27017/connectiveDB
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}

--- a/src/test/java/com/connective/server/user/application/service/AuthServiceImplTest.java
+++ b/src/test/java/com/connective/server/user/application/service/AuthServiceImplTest.java
@@ -1,0 +1,327 @@
+package com.connective.server.user.application.service;
+
+import com.connective.server.user.application.client.GoogleAuthClient;
+import com.connective.server.user.domain.dto.auth.GoogleTokenResponseDTO;
+import com.connective.server.user.domain.dto.auth.GoogleUserInfoResponseDTO;
+import com.connective.server.user.domain.dto.auth.LoginResponseDTO;
+import com.connective.server.user.domain.dto.auth.TokenDTO;
+import com.connective.server.user.domain.entity.User;
+import com.connective.server.user.domain.enums.ProfileCharacterType;
+import com.connective.server.user.domain.enums.SocialProviderType;
+import com.connective.server.user.domain.repository.UserRepository;
+import com.connective.server.user.infrastructure.security.JwtCookieUtil;
+import com.connective.server.user.infrastructure.security.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class AuthServiceImplTest {
+
+    @Mock
+    private GoogleAuthClient googleAuthClient;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private JwtCookieUtil jwtCookieUtil;
+
+    @Mock
+    private RedisService redisService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    private GoogleTokenResponseDTO googleTokenResponse;
+    private GoogleUserInfoResponseDTO googleUserInfo;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        googleTokenResponse = new GoogleTokenResponseDTO();
+        googleTokenResponse.setAccessToken("google-access-token");
+        googleTokenResponse.setRefreshToken("google-refresh-token");
+
+        googleUserInfo = new GoogleUserInfoResponseDTO();
+        googleUserInfo.setId("google-user-id");
+        googleUserInfo.setEmail("test@gmail.com");
+        googleUserInfo.setName("Test User");
+
+        testUser = User.builder()
+            .email("test@gmail.com")
+            .nickname("Test User")
+            .profileCharacterType(ProfileCharacterType.RABBIT)
+            .statusMessage("hihi")
+            .socialProvider(SocialProviderType.GOOGLE)
+            .socialId("google-user-id")
+            .build();
+    }
+
+    @Test
+    @DisplayName("구글 로그인 - 신규 사용자 회원가입")
+    void handleGoogleLogin_NewUser() {
+        // given
+        String code = "auth-code";
+        when(googleAuthClient.requestAccessToken(code)).thenReturn(googleTokenResponse);
+        when(googleAuthClient.requestUserInfo("google-access-token")).thenReturn(googleUserInfo);
+        when(userRepository.findBySocialProviderAndSocialId(SocialProviderType.GOOGLE, "google-user-id"))
+            .thenReturn(Optional.empty());
+        User savedUser = User.builder()
+            .email("test@gmail.com")
+            .nickname("Test User")
+            .profileCharacterType(ProfileCharacterType.RABBIT)
+            .statusMessage("hihi")
+            .socialProvider(SocialProviderType.GOOGLE)
+            .socialId("google-user-id")
+            .build();
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        when(jwtTokenProvider.generateAccessToken(any(User.class))).thenReturn("service-access-token");
+        when(jwtTokenProvider.generateRefreshToken(any(Long.class))).thenReturn("service-refresh-token");
+        when(jwtTokenProvider.getAccessTokenExpiry()).thenReturn(3600000L);
+
+        // when
+        LoginResponseDTO result = authService.handleGoogleLogin(code, response);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo("service-access-token");
+        assertThat(result.getTokenType()).isEqualTo("Bearer");
+        assertThat(result.getExpiresIn()).isEqualTo(3600L);
+
+        verify(userRepository).save(any(User.class));
+        verify(jwtCookieUtil).addRefreshTokenCookie(response, "service-refresh-token");
+    }
+
+    @Test
+    @DisplayName("구글 로그인 - 기존 사용자 정보 업데이트")
+    void handleGoogleLogin_ExistingUser_UpdateInfo() {
+        // given
+        String code = "auth-code";
+        User existingUser = User.builder()
+            .email("old@gmail.com")
+            .nickname("Old Name")
+            .profileCharacterType(ProfileCharacterType.RABBIT)
+            .socialProvider(SocialProviderType.GOOGLE)
+            .socialId("google-user-id")
+            .build();
+
+        when(googleAuthClient.requestAccessToken(code)).thenReturn(googleTokenResponse);
+        when(googleAuthClient.requestUserInfo("google-access-token")).thenReturn(googleUserInfo);
+        when(userRepository.findBySocialProviderAndSocialId(SocialProviderType.GOOGLE, "google-user-id"))
+            .thenReturn(Optional.of(existingUser));
+        when(jwtTokenProvider.generateAccessToken(any(User.class))).thenReturn("service-access-token");
+        when(jwtTokenProvider.generateRefreshToken(any(Long.class))).thenReturn("service-refresh-token");
+        when(jwtTokenProvider.getAccessTokenExpiry()).thenReturn(3600000L);
+
+        // when
+        LoginResponseDTO result = authService.handleGoogleLogin(code, response);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo("service-access-token");
+        verify(userRepository).save(existingUser);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 성공")
+    void reissueTokens_Success() {
+        // given
+        Long userId = 1L;
+        String refreshToken = "refresh-token";
+        String newAccessToken = "new-access-token";
+        String newRefreshToken = "new-refresh-token";
+
+        when(jwtCookieUtil.getRefreshTokenFromCookie(request)).thenReturn(refreshToken);
+        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
+        when(redisService.getValue(String.valueOf(userId))).thenReturn(refreshToken);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(jwtTokenProvider.generateAccessToken(testUser)).thenReturn(newAccessToken);
+        when(jwtTokenProvider.generateRefreshToken(userId)).thenReturn(newRefreshToken);
+        when(jwtTokenProvider.getRefreshTokenExpiry()).thenReturn(604800000L);
+        doNothing().when(redisService).deleteValue(anyString());
+        doNothing().when(redisService).setValues(anyString(), anyString(), any(Duration.class));
+        doNothing().when(jwtCookieUtil).addRefreshTokenCookie(any(HttpServletResponse.class), anyString());
+
+        // when
+        TokenDTO result = authService.reissueTokens(request, response);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo(newAccessToken);
+        assertThat(result.getRefreshToken()).isEqualTo(newRefreshToken);
+
+        verify(redisService).deleteValue(String.valueOf(userId));
+        verify(redisService).setValues(eq(String.valueOf(userId)), eq(newRefreshToken), any(Duration.class));
+        verify(jwtCookieUtil).addRefreshTokenCookie(response, newRefreshToken);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 쿠키에서 토큰 없음")
+    void reissueTokens_NoTokenInCookie() {
+        // given
+        when(jwtCookieUtil.getRefreshTokenFromCookie(request)).thenReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueTokens(request, response))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Refresh Token not found.");
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 유효하지 않은 토큰")
+    void reissueTokens_InvalidToken() {
+        // given
+        String refreshToken = "invalid-refresh-token";
+        when(jwtCookieUtil.getRefreshTokenFromCookie(request)).thenReturn(refreshToken);
+        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueTokens(request, response))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Refresh Token invalid.");
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 토큰에서 사용자 ID 추출 실패")
+    void reissueTokens_NoUserIdInToken() {
+        // given
+        String refreshToken = "refresh-token";
+        when(jwtCookieUtil.getRefreshTokenFromCookie(request)).thenReturn(refreshToken);
+        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueTokens(request, response))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("User ID not found in token.");
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - Redis에 토큰 없음")
+    void reissueTokens_NoTokenInRedis() {
+        // given
+        Long userId = 1L;
+        String refreshToken = "refresh-token";
+        when(jwtCookieUtil.getRefreshTokenFromCookie(request)).thenReturn(refreshToken);
+        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
+        when(redisService.getValue(String.valueOf(userId))).thenReturn(null);
+
+        User mockUser = User.builder()
+            .email("test@gmail.com")
+            .nickname("Test User")
+            .profileCharacterType(ProfileCharacterType.RABBIT)
+            .statusMessage("hihi")
+            .socialProvider(SocialProviderType.GOOGLE)
+            .socialId("google-user-id")
+            .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(jwtTokenProvider.generateAccessToken(any(User.class))).thenReturn("new-access-token");
+        when(jwtTokenProvider.generateRefreshToken(any(Long.class))).thenReturn("new-refresh-token");
+        when(jwtTokenProvider.getRefreshTokenExpiry()).thenReturn(604800000L);
+        doNothing().when(redisService).deleteValue(anyString());
+        doNothing().when(redisService).setValues(anyString(), anyString(), any(Duration.class));
+        doNothing().when(jwtCookieUtil).addRefreshTokenCookie(any(HttpServletResponse.class), anyString());
+
+        // when
+        TokenDTO result = authService.reissueTokens(request, response);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo("new-access-token");
+        assertThat(result.getRefreshToken()).isEqualTo("new-refresh-token");
+        verify(redisService).deleteValue(String.valueOf(userId));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 사용자 없음")
+    void reissueTokens_UserNotFound() {
+        // given
+        Long userId = 1L;
+        String refreshToken = "refresh-token";
+        when(jwtCookieUtil.getRefreshTokenFromCookie(request)).thenReturn(refreshToken);
+        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
+        when(redisService.getValue(String.valueOf(userId))).thenReturn(refreshToken);
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueTokens(request, response))
+            .isInstanceOf(UsernameNotFoundException.class)
+            .hasMessage("User not found with ID: " + userId);
+    }
+
+    @Test
+    @DisplayName("로그아웃 - 성공")
+    void logout_Success() {
+        // given
+        Long userId = 1L;
+        String refreshToken = "refresh-token";
+        when(jwtCookieUtil.getRefreshTokenFromCookie(request)).thenReturn(refreshToken);
+        when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
+
+        // when
+        authService.logout(request, response);
+
+        // then
+        verify(redisService).deleteValue(String.valueOf(userId));
+    }
+
+    @Test
+    @DisplayName("로그아웃 - 쿠키에서 토큰 없음")
+    void logout_NoTokenInCookie() {
+        // given
+        when(jwtCookieUtil.getRefreshTokenFromCookie(request)).thenReturn(null);
+
+        // when
+        authService.logout(request, response);
+
+        // then
+        verify(redisService, never()).deleteValue(anyString());
+    }
+
+    @Test
+    @DisplayName("로그아웃 - 토큰에서 사용자 ID 추출 실패")
+    void logout_NoUserIdInToken() {
+        // given
+        String refreshToken = "refresh-token";
+        when(jwtCookieUtil.getRefreshTokenFromCookie(request)).thenReturn(refreshToken);
+        when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(null);
+
+        // when
+        authService.logout(request, response);
+
+        // then
+        verify(redisService, never()).deleteValue(anyString());
+    }
+}

--- a/src/test/java/com/connective/server/user/presentation/AuthControllerTest.java
+++ b/src/test/java/com/connective/server/user/presentation/AuthControllerTest.java
@@ -1,0 +1,152 @@
+package com.connective.server.user.presentation;
+
+import com.connective.server.user.application.service.AuthService;
+import com.connective.server.user.domain.dto.auth.LoginResponseDTO;
+import com.connective.server.user.domain.dto.auth.TokenDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class,
+    excludeAutoConfiguration = {SecurityAutoConfiguration.class})
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+
+    @Test
+    @DisplayName("구글 콜백 - 성공")
+    void googleCallback_Success() throws Exception {
+        // given
+        String code = "test-authorization-code";
+        LoginResponseDTO loginResponse = LoginResponseDTO.builder()
+            .accessToken("test-access-token")
+            .tokenType("Bearer")
+            .expiresIn(3600L)
+            .build();
+
+        when(authService.handleGoogleLogin(eq(code), any(HttpServletResponse.class)))
+            .thenReturn(loginResponse);
+
+        // when & then
+        mockMvc.perform(get("/auth/google/callback")
+                .param("code", code))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accessToken").value("test-access-token"))
+            .andExpect(jsonPath("$.tokenType").value("Bearer"))
+            .andExpect(jsonPath("$.expiresIn").value(3600));
+    }
+
+    @Test
+    @DisplayName("구글 콜백 - 코드 누락")
+    void googleCallback_MissingCode() throws Exception {
+        // when & then
+        mockMvc.perform(get("/auth/google/callback"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("구글 콜백 - 빈 코드")
+    void googleCallback_EmptyCode() throws Exception {
+        // when & then
+        mockMvc.perform(get("/auth/google/callback")
+                .param("code", ""))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("구글 콜백 - 서비스 예외")
+    void googleCallback_ServiceException() throws Exception {
+        // given
+        String code = "test-authorization-code";
+        when(authService.handleGoogleLogin(eq(code), any(HttpServletResponse.class)))
+            .thenThrow(new RuntimeException("Google login failed"));
+
+        // when & then
+        mockMvc.perform(get("/auth/google/callback")
+                .param("code", code))
+            .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 성공")
+    void reissueTokens_Success() throws Exception {
+        // given
+        TokenDTO tokenDTO = TokenDTO.builder()
+            .accessToken("new-access-token")
+            .refreshToken("new-refresh-token")
+            .build();
+
+        when(authService.reissueTokens(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            .thenReturn(tokenDTO);
+
+        // when & then
+        mockMvc.perform(post("/auth/reissue")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accessToken").value("new-access-token"))
+            .andExpect(jsonPath("$.refreshToken").value("new-refresh-token"));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 실패")
+    void reissueTokens_Failure() throws Exception {
+        // given
+        when(authService.reissueTokens(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+            .thenThrow(new RuntimeException("Invalid refresh token"));
+
+        // when & then
+        mockMvc.perform(post("/auth/reissue")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그아웃 - 성공")
+    void logout_Success() throws Exception {
+        // given
+        doNothing().when(authService).logout(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+        // when & then
+        mockMvc.perform(post("/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string("Logout successful."));
+    }
+
+    @Test
+    @DisplayName("로그아웃 - 실패")
+    void logout_Failure() throws Exception {
+        // given
+        doThrow(new RuntimeException("Logout failed"))
+            .when(authService).logout(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+        // when & then
+        mockMvc.perform(post("/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError())
+            .andExpect(content().string("Failed to logout."));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,36 @@
+spring:
+  application:
+    name: server-test
+
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
+    show-sql: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+google:
+  client-id: test-client-id
+  client-secret: test-client-secret
+  redirect-uri: http://localhost:8080/auth/google/callback
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: warn
+    com:
+      connective: debug


### PR DESCRIPTION
### 설명 (Description)

실시간 채팅 기능 구현을 위한 기반 작업과 인증 기능의 테스트 코드를 추가합니다.

### 체크리스트 (Checklist)

- [x] 코드가 성공적으로 빌드되고 모든 테스트를 통과했습니다.
- [x] 코드에 새로운 경고나 오류가 없습니다.
- [x] 코드 스타일 가이드라인을 따랐습니다.
- [x] 필요한 문서를 업데이트했습니다.
- [x] 관련 이슈 번호를 참조했습니다. (#4)

### 변경 사항 (Changes)

📋 테스트 코드 구현
  - AuthController 단위 테스트 작성 (8개 테스트 케이스)
  - AuthServiceImpl 단위 테스트 작성 (11개 테스트 케이스)
  - 테스트용 H2 데이터베이스 환경 설정 추가
  - 테스트 전용 application-test.yml 프로필 구성

  🔌 실시간 채팅 기반 구조
  - WebSocket 의존성 추가 (spring-boot-starter-websocket)
  - STOMP 메시지 브로커 설정 및 엔드포인트 구성
  - MongoDB 의존성 추가 및 연결 설정
  - CORS 설정 및 SockJS fallback 지원

  🛠 기술적 개선사항
  - 테스트 환경과 프로덕션 환경 분리
  - 정형 데이터(MySQL)와 비정형 데이터(MongoDB) 아키텍처 구성
  - 실시간 통신을 위한 WebSocket 준비

### 관련 이슈 (Related Issues)

- #4 

### 참고 자료 (Screenshots or References) (선택)

 테스트 커버리지:
  - AuthController: Google OAuth 콜백, 토큰 재발급, 로그아웃 기능
  - AuthService: 사용자 등록/로그인, JWT 토큰 관리, Redis 세션 관리

  다음 단계 예정:
  - MongoDB 설정 클래스 및 채팅 도메인 엔티티 구현
  - WebSocket JWT 인증 인터셉터 개발
  - 실시간 채팅 메시지 핸들러 구현

